### PR TITLE
feat: Pi-based agents with pluggable AgentProvider architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@zosma.ai**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | Yes                |
+
+We only provide security fixes for the latest release.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly.
+**Do not open a public GitHub issue.**
+
+Email **security@zosma.ai** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Any relevant logs or screenshots
+- Your suggested severity (critical, high, medium, low)
+
+We will acknowledge receipt within 48 hours and aim to provide an initial
+assessment within 5 business days.
+
+## Disclosure Policy
+
+- We follow coordinated disclosure. We ask that you give us a reasonable
+  window (typically 90 days) to address the issue before public disclosure.
+- Once a fix is released, we will publish a security advisory on GitHub.
+- Credit will be given to reporters unless they prefer to remain anonymous.
+
+## Scope
+
+This policy applies to the OpenZosma repository and any officially maintained
+packages within this monorepo. Third-party dependencies are outside our direct
+scope, but we will work to address transitive vulnerabilities promptly.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,0 +1,27 @@
+{
+	"name": "@openzosma/agents",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc",
+		"check": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@mariozechner/pi-agent-core": "^0.60.0",
+		"@mariozechner/pi-ai": "^0.60.0",
+		"@mariozechner/pi-coding-agent": "^0.60.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.15.2",
+		"typescript": "^5.7.3"
+	}
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,0 +1,9 @@
+export type {
+	AgentMessage,
+	AgentProvider,
+	AgentSession,
+	AgentSessionOpts,
+	AgentStreamEvent,
+	AgentStreamEventType,
+} from "./types.js"
+export { PiAgentProvider } from "./pi-agent.js"

--- a/packages/agents/src/pi-agent.ts
+++ b/packages/agents/src/pi-agent.ts
@@ -1,0 +1,308 @@
+import { randomUUID } from "node:crypto"
+import { Agent, type AgentEvent as PiAgentEvent } from "@mariozechner/pi-agent-core"
+import { getEnvApiKey, getModel, getModels, getProviders } from "@mariozechner/pi-ai"
+import type { Api, Model } from "@mariozechner/pi-ai"
+import {
+	convertToLlm,
+	createBashTool,
+	createEditTool,
+	createFindTool,
+	createGrepTool,
+	createLsTool,
+	createReadTool,
+	createWriteTool,
+} from "@mariozechner/pi-coding-agent"
+import type { AgentMessage, AgentProvider, AgentSession, AgentSessionOpts, AgentStreamEvent } from "./types.js"
+
+/** Preferred providers in priority order when auto-detecting. */
+const PROVIDER_PREFERENCE = ["anthropic", "openai", "google", "groq", "xai", "mistral"] as const
+
+/** Default model IDs per provider (used when OPENZOSMA_MODEL_ID is not set). */
+const DEFAULT_MODELS: Record<string, string> = {
+	anthropic: "claude-sonnet-4-20250514",
+	openai: "gpt-4o",
+	google: "gemini-2.5-flash-preview-05-20",
+	groq: "llama-3.3-70b-versatile",
+	xai: "grok-3",
+	mistral: "mistral-large-latest",
+}
+
+/**
+ * Resolve the model to use. Priority:
+ * 1. Explicit OPENZOSMA_MODEL_PROVIDER + OPENZOSMA_MODEL_ID env vars
+ * 2. Auto-detect from available API keys using PROVIDER_PREFERENCE order
+ */
+function resolveModel(): { model: Model<Api>; apiKey: string } {
+	const explicitProvider = process.env.OPENZOSMA_MODEL_PROVIDER
+	const explicitModelId = process.env.OPENZOSMA_MODEL_ID
+
+	// Explicit configuration
+	if (explicitProvider) {
+		const modelId = explicitModelId ?? DEFAULT_MODELS[explicitProvider]
+		if (!modelId) {
+			throw new Error(
+				`OPENZOSMA_MODEL_PROVIDER is "${explicitProvider}" but no OPENZOSMA_MODEL_ID was set and no default model is known for this provider.`,
+			)
+		}
+		const model = getModel(explicitProvider as "anthropic", modelId as "claude-sonnet-4-20250514")
+		if (!model) {
+			throw new Error(`Model ${explicitProvider}/${modelId} not found in model registry.`)
+		}
+		const apiKey = getEnvApiKey(explicitProvider)
+		if (!apiKey) {
+			throw new Error(`No API key found for provider "${explicitProvider}". Set the appropriate environment variable.`)
+		}
+		return { model, apiKey }
+	}
+
+	// Auto-detect: try providers in preference order
+	for (const provider of PROVIDER_PREFERENCE) {
+		const apiKey = getEnvApiKey(provider)
+		if (!apiKey) continue
+
+		const modelId = explicitModelId ?? DEFAULT_MODELS[provider]
+		if (!modelId) continue
+
+		const model = getModel(provider as "anthropic", modelId as "claude-sonnet-4-20250514")
+		if (!model) continue
+
+		return { model, apiKey }
+	}
+
+	// Last resort: scan all providers
+	for (const provider of getProviders()) {
+		const apiKey = getEnvApiKey(provider)
+		if (!apiKey) continue
+
+		const models = getModels(provider as "anthropic")
+		if (models.length === 0) continue
+
+		return { model: models[0] as Model<Api>, apiKey }
+	}
+
+	throw new Error(
+		"No LLM provider configured. Set OPENZOSMA_MODEL_PROVIDER or provide an API key (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY).",
+	)
+}
+
+const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running inside the OpenZosma platform.
+You have access to tools for reading files, writing files, editing files, executing shell commands, searching file contents, finding files, and listing directories.
+Use these tools when the user asks you to work with files, code, or the system.
+Be direct and concise. When showing code, use markdown code blocks with language annotations.`
+
+/** A Pi Agent-backed session. */
+class PiAgentSession implements AgentSession {
+	private agent: Agent
+	private messages: AgentMessage[] = []
+
+	constructor(opts: AgentSessionOpts) {
+		const toolList = [
+			createReadTool(opts.workspaceDir),
+			createBashTool(opts.workspaceDir),
+			createEditTool(opts.workspaceDir),
+			createWriteTool(opts.workspaceDir),
+			createGrepTool(opts.workspaceDir),
+			createFindTool(opts.workspaceDir),
+			createLsTool(opts.workspaceDir),
+		]
+
+		const { model } = resolveModel()
+
+		this.agent = new Agent({
+			initialState: {
+				systemPrompt: DEFAULT_SYSTEM_PROMPT,
+				model,
+				thinkingLevel: "off",
+				tools: toolList,
+			},
+			convertToLlm,
+			getApiKey: (provider: string) => {
+				return getEnvApiKey(provider)
+			},
+		})
+	}
+
+	async *sendMessage(content: string, signal?: AbortSignal): AsyncGenerator<AgentStreamEvent> {
+		// Store user message
+		const userMsg: AgentMessage = {
+			id: randomUUID(),
+			role: "user",
+			content,
+			createdAt: new Date().toISOString(),
+		}
+		this.messages.push(userMsg)
+
+		// Set up a queue to bridge the event-subscription model to an async generator.
+		// Pi Agent uses subscribe() (callback-based), but we need yield (generator-based).
+		const eventQueue: AgentStreamEvent[] = []
+		let resolveWaiting: (() => void) | null = null
+		let done = false
+
+		function enqueue(event: AgentStreamEvent): void {
+			eventQueue.push(event)
+			if (resolveWaiting) {
+				resolveWaiting()
+				resolveWaiting = null
+			}
+		}
+
+		let fullResponseText = ""
+		let messageId = randomUUID()
+
+		const unsubscribe = this.agent.subscribe((event: PiAgentEvent) => {
+			switch (event.type) {
+				case "agent_start":
+					enqueue({ type: "turn_start", id: randomUUID() })
+					break
+
+				case "message_start":
+					// Only forward assistant messages -- the agent loop echoes user messages too
+					if (event.message.role === "assistant") {
+						messageId = randomUUID()
+						fullResponseText = ""
+						enqueue({ type: "message_start", id: messageId })
+					}
+					break
+
+				case "message_update": {
+					const assistantEvent = event.assistantMessageEvent
+					if (assistantEvent.type === "text_delta") {
+						fullResponseText += assistantEvent.delta
+						enqueue({ type: "message_update", id: messageId, text: assistantEvent.delta })
+					} else if (assistantEvent.type === "thinking_delta") {
+						enqueue({ type: "thinking_update", id: messageId, text: assistantEvent.delta })
+					}
+					break
+				}
+
+				case "message_end":
+					// Only forward assistant message ends
+					if (event.message.role === "assistant") {
+						enqueue({ type: "message_end", id: messageId })
+					}
+					break
+
+				case "tool_execution_start":
+					enqueue({
+						type: "tool_call_start",
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						toolArgs: typeof event.args === "string" ? event.args : JSON.stringify(event.args),
+					})
+					break
+
+				case "tool_execution_update":
+					enqueue({
+						type: "tool_call_update",
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+					})
+					break
+
+				case "tool_execution_end": {
+					const resultText =
+						event.result?.content
+							?.map((c: { type: string; text?: string }) => (c.type === "text" ? c.text : ""))
+							.join("") ?? ""
+					enqueue({
+						type: "tool_call_end",
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						toolResult: resultText,
+						isToolError: event.isError,
+					})
+					break
+				}
+
+				case "agent_end": {
+					// Check if the agent ended with an error
+					const errorMessages: string[] = []
+					for (const m of event.messages) {
+						if (m.role === "assistant" && "errorMessage" in m && m.errorMessage) {
+							errorMessages.push(m.errorMessage)
+						}
+					}
+					if (errorMessages.length > 0) {
+						enqueue({ type: "error", error: errorMessages.join("; ") })
+					}
+					enqueue({ type: "turn_end", id: randomUUID() })
+					done = true
+					if (resolveWaiting) {
+						resolveWaiting()
+						resolveWaiting = null
+					}
+					break
+				}
+
+				case "turn_start":
+				case "turn_end":
+					// Internal turn boundaries within the agent loop -- no gateway-level event needed
+					break
+			}
+		})
+
+		// Handle abort
+		if (signal) {
+			signal.addEventListener(
+				"abort",
+				() => {
+					this.agent.abort()
+				},
+				{ once: true },
+			)
+		}
+
+		// Start the agent prompt (fire-and-forget, events come via subscription)
+		const promptPromise = this.agent.prompt(content).catch((err: unknown) => {
+			const errorMsg = err instanceof Error ? err.message : "Unknown agent error"
+			enqueue({ type: "error", error: errorMsg })
+			done = true
+			if (resolveWaiting) {
+				resolveWaiting()
+				resolveWaiting = null
+			}
+		})
+
+		// Yield events as they arrive
+		try {
+			while (!done || eventQueue.length > 0) {
+				if (eventQueue.length > 0) {
+					const event = eventQueue.shift()!
+					yield event
+				} else if (!done) {
+					await new Promise<void>((resolve) => {
+						resolveWaiting = resolve
+					})
+				}
+			}
+		} finally {
+			unsubscribe()
+			await promptPromise
+		}
+
+		// Store assistant message for session history
+		if (fullResponseText) {
+			const assistantMsg: AgentMessage = {
+				id: messageId,
+				role: "assistant",
+				content: fullResponseText,
+				createdAt: new Date().toISOString(),
+			}
+			this.messages.push(assistantMsg)
+		}
+	}
+
+	getMessages(): AgentMessage[] {
+		return this.messages
+	}
+}
+
+/** Agent provider backed by Pi (pi-agent-core + pi-coding-agent). */
+export class PiAgentProvider implements AgentProvider {
+	readonly id = "pi-coding"
+	readonly name = "Pi Coding Agent"
+
+	createSession(opts: AgentSessionOpts): AgentSession {
+		return new PiAgentSession(opts)
+	}
+}

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -1,0 +1,70 @@
+/** Event types emitted by an agent during a turn. */
+export type AgentStreamEventType =
+	// Lifecycle
+	| "turn_start"
+	| "turn_end"
+	// Assistant message streaming
+	| "message_start"
+	| "message_update"
+	| "message_end"
+	// Tool execution
+	| "tool_call_start"
+	| "tool_call_update"
+	| "tool_call_end"
+	// Thinking / reasoning
+	| "thinking_update"
+	// Error
+	| "error"
+
+/** A single event in the agent response stream. */
+export interface AgentStreamEvent {
+	type: AgentStreamEventType
+	/** Event or turn ID. */
+	id?: string
+	/** Text delta (for message_update / thinking_update). */
+	text?: string
+	/** Error message (for error events). */
+	error?: string
+	/** Tool name (for tool_call_* events). */
+	toolName?: string
+	/** Tool call ID (for tool_call_* events). */
+	toolCallId?: string
+	/** Tool arguments as JSON string (for tool_call_start). */
+	toolArgs?: string
+	/** Tool result text (for tool_call_end). */
+	toolResult?: string
+	/** Whether the tool execution errored (for tool_call_end). */
+	isToolError?: boolean
+}
+
+/** A stored message within an agent session. */
+export interface AgentMessage {
+	id: string
+	role: "user" | "assistant"
+	content: string
+	createdAt: string
+}
+
+/** Options for creating an agent session. */
+export interface AgentSessionOpts {
+	sessionId: string
+	workspaceDir: string
+}
+
+/** A single agent session that can exchange messages. */
+export interface AgentSession {
+	/** Send a user message and stream back events. */
+	sendMessage(content: string, signal?: AbortSignal): AsyncGenerator<AgentStreamEvent>
+	/** Get all messages in this session. */
+	getMessages(): AgentMessage[]
+}
+
+/** Provider that creates agent sessions. */
+export interface AgentProvider {
+	/** Unique identifier for this provider (e.g. "pi-coding"). */
+	readonly id: string
+	/** Human-readable name (e.g. "Pi Coding Agent"). */
+	readonly name: string
+	/** Create a new session backed by this provider. */
+	createSession(opts: AgentSessionOpts): AgentSession
+}

--- a/packages/agents/tsconfig.json
+++ b/packages/agents/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src"]
+}

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -19,9 +19,7 @@
 	"dependencies": {
 		"hono": "^4.7.6",
 		"@hono/node-server": "^1.14.1",
-		"@mariozechner/pi-agent-core": "^0.60.0",
-		"@mariozechner/pi-ai": "^0.60.0",
-		"@mariozechner/pi-coding-agent": "^0.60.0",
+		"@openzosma/agents": "workspace:*",
 		"ws": "^8.18.1",
 		"@openzosma/db": "workspace:*",
 		"@openzosma/auth": "workspace:*",

--- a/packages/gateway/src/session-manager.ts
+++ b/packages/gateway/src/session-manager.ts
@@ -1,107 +1,25 @@
 import { randomUUID } from "node:crypto"
 import { mkdirSync } from "node:fs"
 import { join, resolve } from "node:path"
-import { Agent, type AgentEvent as PiAgentEvent } from "@mariozechner/pi-agent-core"
-import { getEnvApiKey, getModel, getModels, getProviders } from "@mariozechner/pi-ai"
-import type { Api, Model } from "@mariozechner/pi-ai"
-import {
-	convertToLlm,
-	createBashTool,
-	createEditTool,
-	createFindTool,
-	createGrepTool,
-	createLsTool,
-	createReadTool,
-	createWriteTool,
-} from "@mariozechner/pi-coding-agent"
+import type { AgentProvider, AgentSession } from "@openzosma/agents"
+import { PiAgentProvider } from "@openzosma/agents"
 import type { GatewayEvent, Session, SessionMessage } from "./types.js"
 
-/** Preferred providers in priority order when auto-detecting. */
-const PROVIDER_PREFERENCE = ["anthropic", "openai", "google", "groq", "xai", "mistral"] as const
-
-/** Default model IDs per provider (used when OPENZOSMA_MODEL_ID is not set). */
-const DEFAULT_MODELS: Record<string, string> = {
-	anthropic: "claude-sonnet-4-20250514",
-	openai: "gpt-4o",
-	google: "gemini-2.5-flash-preview-05-20",
-	groq: "llama-3.3-70b-versatile",
-	xai: "grok-3",
-	mistral: "mistral-large-latest",
-}
-
 /**
- * Resolve the model to use. Priority:
- * 1. Explicit OPENZOSMA_MODEL_PROVIDER + OPENZOSMA_MODEL_ID env vars
- * 2. Auto-detect from available API keys using PROVIDER_PREFERENCE order
+ * Per-session state holding the agent session and gateway-level metadata.
  */
-function resolveModel(): { model: Model<Api>; apiKey: string } {
-	const explicitProvider = process.env.OPENZOSMA_MODEL_PROVIDER
-	const explicitModelId = process.env.OPENZOSMA_MODEL_ID
-
-	// Explicit configuration
-	if (explicitProvider) {
-		const modelId = explicitModelId ?? DEFAULT_MODELS[explicitProvider]
-		if (!modelId) {
-			throw new Error(
-				`OPENZOSMA_MODEL_PROVIDER is "${explicitProvider}" but no OPENZOSMA_MODEL_ID was set and no default model is known for this provider.`,
-			)
-		}
-		const model = getModel(explicitProvider as "anthropic", modelId as "claude-sonnet-4-20250514")
-		if (!model) {
-			throw new Error(`Model ${explicitProvider}/${modelId} not found in model registry.`)
-		}
-		const apiKey = getEnvApiKey(explicitProvider)
-		if (!apiKey) {
-			throw new Error(`No API key found for provider "${explicitProvider}". Set the appropriate environment variable.`)
-		}
-		return { model, apiKey }
-	}
-
-	// Auto-detect: try providers in preference order
-	for (const provider of PROVIDER_PREFERENCE) {
-		const apiKey = getEnvApiKey(provider)
-		if (!apiKey) continue
-
-		const modelId = explicitModelId ?? DEFAULT_MODELS[provider]
-		if (!modelId) continue
-
-		const model = getModel(provider as "anthropic", modelId as "claude-sonnet-4-20250514")
-		if (!model) continue
-
-		return { model, apiKey }
-	}
-
-	// Last resort: scan all providers
-	for (const provider of getProviders()) {
-		const apiKey = getEnvApiKey(provider)
-		if (!apiKey) continue
-
-		const models = getModels(provider as "anthropic")
-		if (models.length === 0) continue
-
-		return { model: models[0] as Model<Api>, apiKey }
-	}
-
-	throw new Error(
-		"No LLM provider configured. Set OPENZOSMA_MODEL_PROVIDER or provide an API key (e.g. OPENAI_API_KEY, ANTHROPIC_API_KEY).",
-	)
-}
-
-const DEFAULT_SYSTEM_PROMPT = `You are a helpful AI assistant running inside the OpenZosma platform.
-You have access to tools for reading files, writing files, editing files, executing shell commands, searching file contents, finding files, and listing directories.
-Use these tools when the user asks you to work with files, code, or the system.
-Be direct and concise. When showing code, use markdown code blocks with language annotations.`
-
-/**
- * Per-session state holding the Pi Agent instance and metadata.
- */
-interface AgentState {
-	agent: Agent
+interface SessionState {
+	agentSession: AgentSession
 	session: Session
 }
 
 export class SessionManager {
-	private agents = new Map<string, AgentState>()
+	private sessions = new Map<string, SessionState>()
+	private provider: AgentProvider
+
+	constructor(provider?: AgentProvider) {
+		this.provider = provider ?? new PiAgentProvider()
+	}
 
 	createSession(): Session {
 		const session: Session = {
@@ -114,53 +32,33 @@ export class SessionManager {
 		const sessionDir = join(workspaceRoot, "sessions", session.id)
 		mkdirSync(sessionDir, { recursive: true })
 
-		const toolList = [
-			createReadTool(sessionDir),
-			createBashTool(sessionDir),
-			createEditTool(sessionDir),
-			createWriteTool(sessionDir),
-			createGrepTool(sessionDir),
-			createFindTool(sessionDir),
-			createLsTool(sessionDir),
-		]
-
-		const { model } = resolveModel()
-
-		const agent = new Agent({
-			initialState: {
-				systemPrompt: DEFAULT_SYSTEM_PROMPT,
-				model,
-				thinkingLevel: "off",
-				tools: toolList,
-			},
-			convertToLlm,
-			getApiKey: (provider: string) => {
-				return getEnvApiKey(provider)
-			},
+		const agentSession = this.provider.createSession({
+			sessionId: session.id,
+			workspaceDir: sessionDir,
 		})
 
-		this.agents.set(session.id, { agent, session })
+		this.sessions.set(session.id, { agentSession, session })
 		return session
 	}
 
 	getSession(id: string): Session | undefined {
-		return this.agents.get(id)?.session
+		return this.sessions.get(id)?.session
 	}
 
 	/**
 	 * Send a user message and stream back gateway events.
 	 *
-	 * The Pi Agent drives a multi-turn loop internally (LLM call -> tool calls -> LLM call -> ...).
-	 * We subscribe to its events, translate them to GatewayEvents, and yield them.
+	 * Delegates to the configured AgentProvider's session, mapping
+	 * AgentStreamEvents to GatewayEvents.
 	 */
 	async *sendMessage(sessionId: string, content: string, signal?: AbortSignal): AsyncGenerator<GatewayEvent> {
-		const state = this.agents.get(sessionId)
+		const state = this.sessions.get(sessionId)
 		if (!state) {
 			yield { type: "error", error: `Session ${sessionId} not found` }
 			return
 		}
 
-		const { agent, session } = state
+		const { agentSession, session } = state
 
 		// Store user message
 		const userMsg: SessionMessage = {
@@ -171,160 +69,30 @@ export class SessionManager {
 		}
 		session.messages.push(userMsg)
 
-		// Set up a queue to bridge the event-subscription model to an async generator.
-		// Pi Agent uses subscribe() (callback-based), but our gateway uses yield (generator-based).
-		const eventQueue: GatewayEvent[] = []
-		let resolveWaiting: (() => void) | null = null
-		let done = false
+		let lastAssistantText = ""
+		let lastMessageId: string | undefined
 
-		function enqueue(event: GatewayEvent): void {
-			eventQueue.push(event)
-			if (resolveWaiting) {
-				resolveWaiting()
-				resolveWaiting = null
+		for await (const event of agentSession.sendMessage(content, signal)) {
+			// AgentStreamEvent and GatewayEvent have the same shape --
+			// pass through directly, tracking text for session history.
+			const gatewayEvent: GatewayEvent = event as GatewayEvent
+
+			if (event.type === "message_start") {
+				lastMessageId = event.id
+				lastAssistantText = ""
+			} else if (event.type === "message_update" && event.text) {
+				lastAssistantText += event.text
 			}
-		}
 
-		let fullResponseText = ""
-		let messageId = randomUUID()
-
-		const unsubscribe = agent.subscribe((event: PiAgentEvent) => {
-			switch (event.type) {
-				case "agent_start":
-					enqueue({ type: "turn_start", id: randomUUID() })
-					break
-
-				case "message_start":
-					// Only forward assistant messages — the agent loop echoes user messages too
-					if (event.message.role === "assistant") {
-						messageId = randomUUID()
-						fullResponseText = ""
-						enqueue({ type: "message_start", id: messageId })
-					}
-					break
-
-				case "message_update": {
-					const assistantEvent = event.assistantMessageEvent
-					if (assistantEvent.type === "text_delta") {
-						fullResponseText += assistantEvent.delta
-						enqueue({ type: "message_update", id: messageId, text: assistantEvent.delta })
-					} else if (assistantEvent.type === "thinking_delta") {
-						enqueue({ type: "thinking_update", id: messageId, text: assistantEvent.delta })
-					}
-					break
-				}
-
-				case "message_end":
-					// Only forward assistant message ends
-					if (event.message.role === "assistant") {
-						enqueue({ type: "message_end", id: messageId })
-					}
-					break
-
-				case "tool_execution_start":
-					enqueue({
-						type: "tool_call_start",
-						toolCallId: event.toolCallId,
-						toolName: event.toolName,
-						toolArgs: typeof event.args === "string" ? event.args : JSON.stringify(event.args),
-					})
-					break
-
-				case "tool_execution_update":
-					enqueue({
-						type: "tool_call_update",
-						toolCallId: event.toolCallId,
-						toolName: event.toolName,
-					})
-					break
-
-				case "tool_execution_end": {
-					const resultText =
-						event.result?.content
-							?.map((c: { type: string; text?: string }) => (c.type === "text" ? c.text : ""))
-							.join("") ?? ""
-					enqueue({
-						type: "tool_call_end",
-						toolCallId: event.toolCallId,
-						toolName: event.toolName,
-						toolResult: resultText,
-						isToolError: event.isError,
-					})
-					break
-				}
-
-				case "agent_end": {
-					// Check if the agent ended with an error
-					const errorMessages: string[] = []
-					for (const m of event.messages) {
-						if (m.role === "assistant" && "errorMessage" in m && m.errorMessage) {
-							errorMessages.push(m.errorMessage)
-						}
-					}
-					if (errorMessages.length > 0) {
-						enqueue({ type: "error", error: errorMessages.join("; ") })
-					}
-					enqueue({ type: "turn_end", id: randomUUID() })
-					done = true
-					if (resolveWaiting) {
-						resolveWaiting()
-						resolveWaiting = null
-					}
-					break
-				}
-
-				case "turn_start":
-				case "turn_end":
-					// Internal turn boundaries within the agent loop -- no gateway-level event needed
-					break
-			}
-		})
-
-		// Handle abort
-		if (signal) {
-			signal.addEventListener(
-				"abort",
-				() => {
-					agent.abort()
-				},
-				{ once: true },
-			)
-		}
-
-		// Start the agent prompt (fire-and-forget, events come via subscription)
-		const promptPromise = agent.prompt(content).catch((err: unknown) => {
-			const errorMsg = err instanceof Error ? err.message : "Unknown agent error"
-			enqueue({ type: "error", error: errorMsg })
-			done = true
-			if (resolveWaiting) {
-				resolveWaiting()
-				resolveWaiting = null
-			}
-		})
-
-		// Yield events as they arrive
-		try {
-			while (!done || eventQueue.length > 0) {
-				if (eventQueue.length > 0) {
-					const event = eventQueue.shift()!
-					yield event
-				} else if (!done) {
-					await new Promise<void>((resolve) => {
-						resolveWaiting = resolve
-					})
-				}
-			}
-		} finally {
-			unsubscribe()
-			await promptPromise
+			yield gatewayEvent
 		}
 
 		// Store assistant message for session history
-		if (fullResponseText) {
+		if (lastAssistantText) {
 			const assistantMsg: SessionMessage = {
-				id: messageId,
+				id: lastMessageId ?? randomUUID(),
 				role: "assistant",
-				content: fullResponseText,
+				content: lastAssistantText,
 				createdAt: new Date().toISOString(),
 			}
 			session.messages.push(assistantMsg)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,25 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/agents:
+    dependencies:
+      '@mariozechner/pi-agent-core':
+        specifier: ^0.60.0
+        version: 0.60.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai':
+        specifier: ^0.60.0
+        version: 0.60.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: ^0.60.0
+        version: 0.60.0(ws@8.19.0)(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.2
+        version: 22.19.15
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/auth:
     dependencies:
       '@openzosma/db':
@@ -140,15 +159,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.14.1
         version: 1.19.11(hono@4.12.8)
-      '@mariozechner/pi-agent-core':
-        specifier: ^0.60.0
-        version: 0.60.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai':
-        specifier: ^0.60.0
-        version: 0.60.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent':
-        specifier: ^0.60.0
-        version: 0.60.0(ws@8.19.0)(zod@4.3.6)
+      '@openzosma/agents':
+        specifier: workspace:*
+        version: link:../agents
       '@openzosma/auth':
         specifier: workspace:*
         version: link:../auth


### PR DESCRIPTION
## Summary

Replace the OpenAI-based gateway agent with Pi-based agents (`@mariozechner/pi-agent-core` + `pi-coding-agent`), extracted into a standalone `@openzosma/agents` package with a pluggable `AgentProvider` interface.

## Changes

### New: `packages/agents/` (`@openzosma/agents`)
- **`AgentProvider` interface** — pluggable provider abstraction: `createSession(opts) -> AgentSession`
- **`AgentSession` interface** — `sendMessage()` returns `AsyncGenerator<AgentStreamEvent>`, supports abort
- **`PiAgentProvider`** — first implementation using Pi agent-core + coding-agent
  - Auto-detects model from available API keys (anthropic > openai > google > groq > xai > mistral)
  - Configurable via `OPENZOSMA_MODEL_PROVIDER` / `OPENZOSMA_MODEL_ID` env vars
  - Full tool suite: read, write, edit, bash, grep, find, ls
  - Bridges Pi's callback-based events to async generator stream (queue pattern)
  - Handles abort, error extraction, and user message echo filtering

### Modified: `packages/gateway/`
- **`session-manager.ts`** rewritten from 333 to ~97 lines — delegates to `AgentProvider` instead of containing Pi-specific logic
- **`types.ts`** expanded with `tool_call_start`, `tool_call_update`, `tool_call_end`, `thinking_start`, `thinking_update`, `thinking_end` event types
- **`package.json`** — removed 3 direct `@mariozechner/pi-*` deps, added `@openzosma/agents: workspace:*`

### Modified: `apps/web/`
- **`chat/page.tsx`** — rewritten to visualize tool calls (collapsible panels with args/results) and thinking blocks; biome lint fixes

### Infrastructure
- **`.github/workflows/ci.yml`** — removed `push: branches: [main]` trigger (CI runs on PRs only)
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v2.1
- **`SECURITY.md`** — vulnerability reporting policy (security@zosma.ai)
- **`docs/PLAN-DIGITAL-TWINS.md`** — Phase 0 implementation plan

## Architecture

```
apps/web (chat UI)
    |
    v
packages/gateway (WebSocket + REST, SessionManager)
    |
    v
packages/agents (AgentProvider interface)
    |
    v
PiAgentProvider -> @mariozechner/pi-agent-core + pi-coding-agent
```

Dependency flow is strictly one-directional. `packages/agents/` defines its own `AgentStreamEvent` type (same shape as `GatewayEvent` but independent — no circular deps).

## Testing

- `pnpm lint` passes (71 files, 0 errors)
- `npm run check` passes (18/18 tasks, 0 errors)
