### PR TITLE
docs: rewrite README with business-first vision, move setup details to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,9 @@ DB_PORT=5432
 DB_NAME=openzosma
 DB_USER=openzosma
 DB_PASS=openzosma
-# Or set DATABASE_URL directly (takes precedence over DB_* vars)
+DB_POOL_SIZE=10
+# Or set DATABASE_URL directly (takes precedence over DB_* vars), for example:
+# DATABASE_URL=postgres://openzosma:openzosma@localhost:5432/openzosma
 
 # Auth
 BETTER_AUTH_SECRET=<random-secret>
@@ -153,6 +155,7 @@ VALKEY_URL=redis://localhost:6379
 RABBITMQ_URL=amqp://openzosma:openzosma@localhost:5672
 
 # gRPC
+ORCHESTRATOR_GRPC_HOST=0.0.0.0
 ORCHESTRATOR_GRPC_PORT=50051
 SANDBOX_GRPC_PORT=50052
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git clone https://github.com/zosmaai/openzosma.git
 cd openzosma
 pnpm install
 
-# Start PostgreSQL (with pgvector)
+# Start services: PostgreSQL (with pgvector), Valkey, and RabbitMQ
 docker compose up -d
 
 # Configure environment


### PR DESCRIPTION
## Summary

- Rewrote README to lead with the product vision (hierarchical AI agents as digital work twins, phone-first access) instead of technical setup instructions
- Added concrete business example showing agent hierarchy (CEO > Sales/Operations/Support agents)
- Moved detailed setup, migration, Docker, and environment variable docs from README to CONTRIBUTING.md
- Updated CONTRIBUTING.md with current commands (db-migrate, .env.local symlink, Biome) and complete env var reference

## Changes

### README.md
- New hero section: "Build AI teams that work alongside yours -- accessible from your phone"
- "How It Works" with org-chart-style agent hierarchy diagram and WhatsApp usage example
- Key features focused on business value (hierarchical agents, talk from anywhere, self-hosted, secure, open source)
- Condensed quick start (12 lines, links to CONTRIBUTING.md for full setup)
- Removed: database migration deep-dive, Docker dev/prod commands, implementation phases table, detailed env var tables (all moved to CONTRIBUTING.md or linked docs)

### CONTRIBUTING.md
- Absorbed full setup instructions from README (docker compose, .env.local symlink, migration commands)
- Updated migration section to reflect db-migrate (was referencing node-pg-migrate)
- Added Biome to code style conventions
- Added complete environment variables reference
- Added Docker production build instructions