### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/apps/web/src/components/ai-elements/web-preview.tsx
+++ b/apps/web/src/components/ai-elements/web-preview.tsx
@@ -136,15 +136,42 @@ export type WebPreviewBodyProps = ComponentProps<"iframe"> & {
 	loading?: ReactNode
 }
 
+// Sanitize user-controlled URLs before using them as iframe sources.
+const sanitizeUrl = (rawUrl: string): string | undefined => {
+	if (!rawUrl) {
+		return undefined
+	}
+
+	let urlToParse = rawUrl.trim()
+
+	// If the user did not include a scheme, default to https.
+	if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(urlToParse)) {
+		urlToParse = `https://${urlToParse}`
+	}
+
+	try {
+		const parsed = new URL(urlToParse)
+		if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+			return parsed.toString()
+		}
+	} catch {
+		// Invalid URL; fall through to undefined.
+	}
+
+	return undefined
+}
+
 export const WebPreviewBody = ({ className, loading, src, ...props }: WebPreviewBodyProps) => {
 	const { url } = useWebPreview()
+
+	const safeSrc = src ?? sanitizeUrl(url)
 
 	return (
 		<div className="flex-1">
 			<iframe
 				className={cn("size-full", className)}
 				sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
-				src={(src ?? url) || undefined}
+				src={safeSrc}
 				title="Preview"
 				{...props}
 			/>


### PR DESCRIPTION
Potential fix for [https://github.com/zosmaai/openzosma/security/code-scanning/10](https://github.com/zosmaai/openzosma/security/code-scanning/10)

In general, the right way to fix this kind of issue is to ensure that any user-controlled text used as a URL is validated and normalized before being embedded into the DOM, and that only safe URL schemes and forms are allowed. This prevents a wide range of issues, including dangerous schemes (`javascript:`, `data:`, `vbscript:`), protocol-relative URLs that might hit unexpected origins, and malformed URLs that could confuse other parts of the app.

For this specific component, the simplest non-breaking fix is:

1. Introduce a small helper that "sanitizes" URLs:
   - Accept only `http:` and `https:` URLs (and optionally treat bare host/path inputs as `https://`).
   - Use the standard `URL` constructor for parsing, and catch errors for invalid URLs.
   - Return `undefined` if the URL is invalid or uses an unsupported scheme, so the iframe does not navigate.
2. Use this helper at the point where the iframe `src` is determined:
   - Instead of `(src ?? url) || undefined`, compute a `safeSrc` value:
     - If an explicit `src` prop is passed, prefer and trust that (as it is controlled by the app code).
     - Otherwise, sanitize the context `url` from user input.
   - Pass `safeSrc` as the `src` attribute.

All of this can be implemented inside the existing file with no change to exports or consumers. We don’t need additional libraries; we can rely on the built-in `URL` class. Concretely:

- In `WebPreviewBody`, before the `return`, derive `const safeSrc = src ?? sanitizeUrl(url)` using a new `sanitizeUrl` function defined in this file (above or within the component).
- Replace `src={(src ?? url) || undefined}` with `src={safeSrc}`.
- Add the `sanitizeUrl` helper in the same file, using `try { new URL(...) } catch {}` and checking the protocol.

This preserves existing behavior for valid `http(s)` URLs while preventing navigation to unexpected schemes or malformed URLs, addressing the taint warning without altering the visible API of the component.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
