### PR TITLE
feat(adapter): implement Slack channel adapter with Socket Mode

### DIFF
--- a/packages/adapters/slack/package.json
+++ b/packages/adapters/slack/package.json
@@ -17,7 +17,8 @@
 	},
 	"dependencies": {
 		"@openzosma/db": "workspace:*",
-		"@openzosma/grpc": "workspace:*"
+		"@openzosma/gateway": "workspace:*",
+		"@slack/bolt": "^4.3.0"
 	},
 	"devDependencies": {
 		"@types/node": "^22.15.2",

--- a/packages/adapters/slack/src/index.ts
+++ b/packages/adapters/slack/src/index.ts
@@ -1,3 +1,90 @@
-// Slack Adapter - Socket Mode / Events API integration.
-// Implementation in Phase 5.
-export {}
+import { App, type SlackEventMiddlewareArgs, type AllMiddlewareArgs } from "@slack/bolt"
+import type { SessionManager } from "@openzosma/gateway/session-manager"
+import type { ChannelAdapter } from "@openzosma/gateway/adapters"
+import type { GatewayEvent } from "@openzosma/gateway/types"
+
+export interface SlackAdapterConfig {
+	botToken: string
+	appToken?: string
+}
+
+type MessageEvent = SlackEventMiddlewareArgs<"message"> & AllMiddlewareArgs
+
+/**
+ * Slack channel adapter using Bolt's Socket Mode.
+ *
+ * Maps Slack threads (channel + thread_ts) to orchestrator sessions and
+ * streams agent responses back as threaded replies.
+ */
+export class SlackAdapter implements ChannelAdapter {
+	readonly name = "slack"
+	private app: App
+	private config: SlackAdapterConfig
+	private sessionManager: SessionManager | undefined
+	private sessionMap = new Map<string, string>()
+
+	constructor(config: SlackAdapterConfig) {
+		this.config = config
+		this.app = new App({
+			token: config.botToken,
+			appToken: config.appToken,
+			socketMode: Boolean(config.appToken),
+		})
+	}
+
+	async init(sessionManager: SessionManager): Promise<void> {
+		this.sessionManager = sessionManager
+		this.app.message(this.handleMessage.bind(this))
+		await this.app.start()
+	}
+
+	async shutdown(): Promise<void> {
+		await this.app.stop()
+	}
+
+	private threadKey(channel: string, threadTs: string): string {
+		return `slack:${channel}:${threadTs}`
+	}
+
+	private async getOrCreateSession(channel: string, threadTs: string): Promise<string> {
+		const key = this.threadKey(channel, threadTs)
+		const existing = this.sessionMap.get(key)
+		if (existing) return existing
+
+		const session = await this.sessionManager!.createSession()
+		this.sessionMap.set(key, session.id)
+		return session.id
+	}
+
+	private async handleMessage({ message, say }: MessageEvent): Promise<void> {
+		if (!this.sessionManager) return
+		if (!("text" in message) || !message.text) return
+		if ("bot_id" in message) return
+
+		const channel = message.channel
+		const threadTs = ("thread_ts" in message ? message.thread_ts : message.ts) ?? message.ts
+		const userText = message.text
+
+		const sessionId = await this.getOrCreateSession(channel, threadTs)
+
+		const controller = new AbortController()
+		const events = this.sessionManager.sendMessage(sessionId, userText, controller.signal)
+
+		let fullResponse = ""
+
+		for await (const event of events) {
+			const typed = event as GatewayEvent
+			if (typed.type === "message_update" && typed.content) {
+				fullResponse += typed.content
+			}
+			if (typed.type === "error") {
+				await say({ text: `Error: ${typed.error ?? "unknown error"}`, thread_ts: threadTs })
+				return
+			}
+		}
+
+		if (fullResponse) {
+			await say({ text: fullResponse, thread_ts: threadTs })
+		}
+	}
+}

--- a/packages/gateway/src/adapters.ts
+++ b/packages/gateway/src/adapters.ts
@@ -1,0 +1,42 @@
+import type { SessionManager } from "./session-manager.js"
+
+/**
+ * Common contract for all channel adapters (Slack, WhatsApp, etc.).
+ *
+ * Adapters are lightweight translators: they receive inbound messages from
+ * an external platform, map them to orchestrator sessions, and stream
+ * agent responses back to the platform. They contain no business logic.
+ */
+export interface ChannelAdapter {
+	/** Human-readable adapter name used in logs. */
+	readonly name: string
+	/** Start the adapter (connect to platform, register event handlers). */
+	init(sessionManager: SessionManager): Promise<void>
+	/** Gracefully disconnect and release resources. */
+	shutdown(): Promise<void>
+}
+
+/**
+ * Initialize all configured channel adapters at gateway startup.
+ * Adapters are enabled by the presence of their required env vars.
+ */
+export async function initAdapters(sessionManager: SessionManager): Promise<ChannelAdapter[]> {
+	const adapters: ChannelAdapter[] = []
+
+	if (process.env.SLACK_BOT_TOKEN) {
+		const { SlackAdapter } = await import("@openzosma/adapter-slack")
+		adapters.push(
+			new SlackAdapter({
+				botToken: process.env.SLACK_BOT_TOKEN,
+				appToken: process.env.SLACK_APP_TOKEN,
+			}),
+		)
+	}
+
+	for (const adapter of adapters) {
+		await adapter.init(sessionManager)
+		console.log(`Adapter started: ${adapter.name}`)
+	}
+
+	return adapters
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -3,6 +3,7 @@ import { serve } from "@hono/node-server"
 import { createAuthFromEnv } from "@openzosma/auth"
 import { createPool } from "@openzosma/db"
 import { WebSocketServer } from "ws"
+import { initAdapters } from "./adapters.js"
 import { createApp } from "./app.js"
 import { SessionManager } from "./session-manager.js"
 import { handleWebSocket } from "./ws.js"
@@ -61,4 +62,14 @@ server.on("upgrade", (request, socket, head) => {
 
 wss.on("connection", (ws) => {
 	handleWebSocket(ws, sessionManager)
+})
+
+// Start channel adapters (Slack, WhatsApp, etc.) when their env vars are set
+const adapters = await initAdapters(sessionManager)
+
+process.on("SIGTERM", async () => {
+	for (const adapter of adapters) {
+		await adapter.shutdown()
+	}
+	process.exit(0)
 })


### PR DESCRIPTION
Closes #27

Implements the `ChannelAdapter` interface and a working Slack adapter following the architecture described in `PHASE-5-ADAPTERS.md`.

## Changes

### `packages/gateway/src/adapters.ts` (new)
- Defines the `ChannelAdapter` interface: `name`, `init(sessionManager)`, `shutdown()`
- `initAdapters()` discovers adapters via env vars and initializes them at startup

### `packages/adapters/slack/src/index.ts` (was empty stub)
- `SlackAdapter` using `@slack/bolt` in Socket Mode
- Maps Slack threads (`channel + thread_ts`) to orchestrator sessions
- Streams agent responses back as threaded replies
- Ignores bot messages to prevent loops

### `packages/adapters/slack/package.json`
- Added `@slack/bolt` dependency
- Added `@openzosma/gateway` workspace dependency for type imports

### `packages/gateway/src/index.ts`
- Wires adapter initialization after server startup
- Graceful adapter shutdown on `SIGTERM`

## Configuration

Set these env vars to enable the Slack adapter:

```bash
SLACK_BOT_TOKEN=xoxb-...     # Required
SLACK_APP_TOKEN=xapp-...     # Required for Socket Mode
```

When `SLACK_BOT_TOKEN` is not set, the adapter is simply not loaded (zero impact on existing functionality).

## What's NOT in this PR (follow-ups)

- Valkey-based session mapping (currently uses in-memory Map -- sufficient for single-instance dev)
- Slack user -> OpenZosma user resolution via the `users` table
- HTTP Events API mode (for production multi-instance deployments)
- Message formatting (mrkdwn conversion, tool output as collapsed blocks)
- Rate limit handling and retry headers
- WhatsApp adapter (separate issue)
