### PR TITLE
fix(security): fix all CodeQL security vulnerabilities + README update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ You (from your phone, WhatsApp, or Slack)
 
 Agents don't replace your team. They handle the routine lookups, status checks, data entry, and coordination that eat up your team's day -- so your people can focus on work that requires human judgment.
 
-> **Note:** The gateway `dev` script loads `../../.env.local` automatically via `--env-file`. If you need a different env file, run `npx tsx --env-file=<path> src/index.ts` from `packages/gateway/`. When `.env.local` has `DB_HOST` or `DATABASE_URL` set, the gateway connects to PostgreSQL and enables A2A per-agent routes.
-
-### Full Setup
-
 ## Key Features
 
 * **Hierarchical agents** -- Configure org-chart-like agent trees. Manager agents delegate to specialist agents automatically.
@@ -50,6 +46,26 @@ Agents don't replace your team. They handle the routine lookups, status checks, 
 
 ## Quick Start
 
+The fastest way to get running is the interactive setup CLI. It handles cloning, environment configuration, Docker services, database migrations, and the initial build in one shot:
+
+```bash
+pnpm create openzosma
+```
+
+or with npx:
+
+```bash
+npx create-openzosma
+```
+
+The CLI walks you through choosing an LLM provider, configuring PostgreSQL, setting up auth secrets, and optionally enabling sandboxed execution. At the end it offers to start the gateway and dashboard for you.
+
+**Already cloned the repo?** Run `pnpm setup` from the repo root instead. The CLI detects the existing checkout and skips the clone step.
+
+### Manual Setup
+
+If you prefer to configure things by hand:
+
 ```bash
 git clone https://github.com/zosmaai/openzosma.git
 cd openzosma
@@ -60,19 +76,23 @@ docker compose up -d
 
 # Configure environment
 cp .env.example .env.local
-# Edit .env.local with your API keys and secrets
+# Edit .env.local -- at minimum set an LLM API key and AUTH_SECRET
 
 # Run database migrations
 pnpm db:migrate
 pnpm db:migrate:auth
 
-# Build and start
+# Build all packages
 pnpm run build
+
+# Start the gateway and dashboard in separate terminals
 pnpm --filter @openzosma/gateway dev   # Terminal 1 (port 4000)
 pnpm --filter @openzosma/web dev       # Terminal 2 (port 3000)
 ```
 
 Open <http://localhost:3000>, sign up, and start a conversation.
+
+> **Note:** The gateway `dev` script loads `../../.env.local` automatically via `--env-file`. If you need a different env file, run `npx tsx --env-file=<path> src/index.ts` from `packages/gateway/`.
 
 ### Running with Sandboxes (Optional)
 

--- a/apps/web/src/app/api/integrations/[integrationid]/query/route.ts
+++ b/apps/web/src/app/api/integrations/[integrationid]/query/route.ts
@@ -37,36 +37,6 @@ function decryptconfig(stored: {
 	}
 }
 
-// ─── Read-only enforcement ────────────────────────────────────────────────────
-
-const BLOCKED_KEYWORDS = [
-	"INSERT",
-	"UPDATE",
-	"DELETE",
-	"DROP",
-	"ALTER",
-	"CREATE",
-	"TRUNCATE",
-	"GRANT",
-	"REVOKE",
-	"EXEC",
-	"EXECUTE",
-]
-
-function isreadonly(query: string): boolean {
-	const normalized = query.trim().toUpperCase()
-	return !BLOCKED_KEYWORDS.some((kw) => normalized.startsWith(kw) || normalized.includes(` ${kw} `))
-}
-
-/**
- * If the query does not already contain a LIMIT clause, append one as a safety cap.
- */
-function ensafelimit(query: string, maxrows = 1000): string {
-	const upper = query.trim().toUpperCase()
-	if (upper.includes("LIMIT")) return query
-	return `${query.trimEnd()}\nLIMIT ${maxrows}`
-}
-
 // ─── POST ─────────────────────────────────────────────────────────────────────
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ integrationid: string }> }) {
@@ -87,9 +57,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 		}
 
 		// ── Read-only enforcement ──
-		if (!isreadonly(query)) {
-			return NextResponse.json({ error: "Only read-only queries are allowed" }, { status: 422 })
-		}
+		// Note: read-only checks and LIMIT enforcement are handled inside
+		// executequery() at both the application and database level.
 
 		// ── Fetch integration ──
 		const integrationresult = await pool.query(
@@ -112,8 +81,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
 		// ── Decrypt config and execute query ──
 		const config = decryptconfig(integration.config)
-		const safequery = ensafelimit(query.trim())
-		const result = await executequery(integration.type, config, safequery)
+		const result = await executequery(integration.type, config, query.trim())
 
 		if (result.success) {
 			return NextResponse.json({

--- a/apps/web/src/components/organisms/chat-view/hooks/use-chat-stream.ts
+++ b/apps/web/src/components/organisms/chat-view/hooks/use-chat-stream.ts
@@ -140,12 +140,12 @@ const useChatStream = (
 				const ws = new WebSocket(wsurl)
 				let fullcontent = ""
 				let fullreasoning = ""
-				const toolcalls: Record<string, StreamToolCall> = {}
+				const toolcalls = new Map<string, StreamToolCall>()
 				const segments: MessageSegment[] = []
 				const allartifacts: FileArtifact[] = []
 
 				const updatetoolcalls = () => {
-					setStreamingtoolcalls(Object.values(toolcalls))
+					setStreamingtoolcalls(Array.from(toolcalls.values()))
 				}
 
 				const updatesegments = () => {
@@ -198,12 +198,12 @@ const useChatStream = (
 											parsedargs = toolArgs
 										}
 									}
-									toolcalls[toolCallId] = {
+									toolcalls.set(toolCallId, {
 										toolcallid: toolCallId,
 										toolname: toolName || "unknown",
 										args: parsedargs,
 										state: "calling",
-									}
+									})
 									segments.push({ type: "tool", toolcallid: toolCallId })
 									updatetoolcalls()
 									updatesegments()
@@ -212,8 +212,8 @@ const useChatStream = (
 							}
 							case "tool_call_update": {
 								const { toolCallId, toolResult } = evt
-								if (toolCallId && toolcalls[toolCallId]) {
-									const existing = toolcalls[toolCallId]
+								if (toolCallId && toolcalls.has(toolCallId)) {
+									const existing = toolcalls.get(toolCallId)!
 									const rawtext = typeof existing.result === "string" ? existing.result : ""
 									existing.result = rawtext + (toolResult || "")
 									existing.state = "streaming-args"
@@ -224,19 +224,20 @@ const useChatStream = (
 							case "tool_call_end": {
 								const { toolCallId, toolResult, isToolError } = evt
 								if (toolCallId) {
-									if (toolcalls[toolCallId]) {
-										toolcalls[toolCallId].result = toolResult
-										toolcalls[toolCallId].iserror = isToolError
-										toolcalls[toolCallId].state = isToolError ? "error" : "result"
+									if (toolcalls.has(toolCallId)) {
+										const existing = toolcalls.get(toolCallId)!
+										existing.result = toolResult
+										existing.iserror = isToolError
+										existing.state = isToolError ? "error" : "result"
 									} else {
-										toolcalls[toolCallId] = {
+										toolcalls.set(toolCallId, {
 											toolcallid: toolCallId,
 											toolname: evt.toolName || "unknown",
 											args: {},
 											state: isToolError ? "error" : "result",
 											result: toolResult,
 											iserror: isToolError,
-										}
+										})
 										segments.push({ type: "tool", toolcallid: toolCallId })
 										updatesegments()
 									}
@@ -300,8 +301,8 @@ const useChatStream = (
 							senderid: agentparticipant.participantid,
 							content: fullcontent,
 							metadata:
-								Object.keys(toolcalls).length > 0
-									? { toolcalls: Object.values(toolcalls), segments }
+								toolcalls.size > 0
+									? { toolcalls: Array.from(toolcalls.values()), segments }
 									: segments.length > 0
 										? { segments }
 										: {},

--- a/apps/web/src/lib/db-connectors.ts
+++ b/apps/web/src/lib/db-connectors.ts
@@ -110,6 +110,41 @@ export async function testconnection(type: string, config: ConnectionConfig): Pr
 	}
 }
 
+// ─── Read-only enforcement ────────────────────────────────────────────────────
+
+const BLOCKED_KEYWORDS = [
+	"INSERT",
+	"UPDATE",
+	"DELETE",
+	"DROP",
+	"ALTER",
+	"CREATE",
+	"TRUNCATE",
+	"GRANT",
+	"REVOKE",
+	"EXEC",
+	"EXECUTE",
+]
+
+/**
+ * Check that a query is read-only by inspecting its keywords.
+ * This is an application-level safety check; the database-level read-only
+ * transaction provides the authoritative enforcement.
+ */
+function isreadonly(query: string): boolean {
+	const normalized = query.trim().toUpperCase()
+	return !BLOCKED_KEYWORDS.some((kw) => normalized.startsWith(kw) || normalized.includes(` ${kw} `))
+}
+
+/**
+ * If the query does not already contain a LIMIT clause, append one as a safety cap.
+ */
+function ensafelimit(query: string, maxrows = 1000): string {
+	const upper = query.trim().toUpperCase()
+	if (upper.includes("LIMIT")) return query
+	return `${query.trimEnd()}\nLIMIT ${maxrows}`
+}
+
 // ─── Query Execution ──────────────────────────────────────────────────────────
 
 export type QueryResult = {
@@ -124,9 +159,19 @@ export type QueryResult = {
 const QUERY_TIMEOUT_MS = 30_000 // 30 seconds
 
 /**
- * Execute a SQL query against a PostgreSQL database.
+ * Execute a read-only SQL query against a PostgreSQL database.
+ *
+ * The query is user-provided by design (authenticated users run SQL against
+ * their own connected databases). Safety is enforced at two levels:
+ * 1. Application-level keyword blocklist (defense in depth)
+ * 2. Database-level read-only transaction (authoritative enforcement)
  */
 export async function querypostgresql(config: ConnectionConfig, query: string): Promise<QueryResult> {
+	if (!isreadonly(query)) {
+		return { success: false, rows: [], fields: [], rowcount: 0, error: "Only read-only queries are allowed" }
+	}
+
+	const safequery = ensafelimit(query)
 	const start = Date.now()
 	const pool = new PgPool({
 		host: config.host,
@@ -142,7 +187,11 @@ export async function querypostgresql(config: ConnectionConfig, query: string): 
 	try {
 		const client = await pool.connect()
 		try {
-			const result = await client.query(query)
+			// Enforce read-only at the database level so the server rejects
+			// any write attempt regardless of the keyword check above.
+			await client.query("BEGIN TRANSACTION READ ONLY")
+			const result = await client.query(safequery) // CodeQL[js/sql-injection] -- intentionally user-provided; guarded by read-only transaction
+			await client.query("COMMIT")
 			const latencyms = Date.now() - start
 			return {
 				success: true,
@@ -151,6 +200,9 @@ export async function querypostgresql(config: ConnectionConfig, query: string): 
 				rowcount: result.rowCount ?? result.rows?.length ?? 0,
 				latencyms,
 			}
+		} catch (error) {
+			await client.query("ROLLBACK").catch(() => {})
+			throw error
 		} finally {
 			client.release()
 		}
@@ -169,9 +221,19 @@ export async function querypostgresql(config: ConnectionConfig, query: string): 
 }
 
 /**
- * Execute a SQL query against a MySQL / MariaDB database.
+ * Execute a read-only SQL query against a MySQL / MariaDB database.
+ *
+ * The query is user-provided by design (authenticated users run SQL against
+ * their own connected databases). Safety is enforced at two levels:
+ * 1. Application-level keyword blocklist (defense in depth)
+ * 2. Database-level read-only transaction (authoritative enforcement)
  */
 export async function querymysql(config: ConnectionConfig, query: string): Promise<QueryResult> {
+	if (!isreadonly(query)) {
+		return { success: false, rows: [], fields: [], rowcount: 0, error: "Only read-only queries are allowed" }
+	}
+
+	const safequery = ensafelimit(query)
 	const start = Date.now()
 	let connection: mysql.Connection | null = null
 
@@ -186,10 +248,14 @@ export async function querymysql(config: ConnectionConfig, query: string): Promi
 			connectTimeout: 10_000,
 		})
 
-		// Set query timeout
+		// Set query timeout and enforce read-only at the database level
 		await connection.query(`SET SESSION MAX_EXECUTION_TIME = ${QUERY_TIMEOUT_MS}`)
+		await connection.query("SET SESSION TRANSACTION READ ONLY")
+		await connection.query("START TRANSACTION")
 
-		const [rows, fields] = await connection.query(query)
+		const [rows, fields] = await connection.query(safequery) // CodeQL[js/sql-injection] -- intentionally user-provided; guarded by read-only transaction
+		await connection.query("COMMIT")
+
 		const latencyms = Date.now() - start
 		const rowarray = Array.isArray(rows) ? rows : []
 		return {
@@ -200,6 +266,9 @@ export async function querymysql(config: ConnectionConfig, query: string): Promi
 			latencyms,
 		}
 	} catch (error) {
+		if (connection) {
+			await connection.query("ROLLBACK").catch(() => {})
+		}
 		return {
 			success: false,
 			rows: [],
@@ -217,6 +286,7 @@ export async function querymysql(config: ConnectionConfig, query: string): Promi
 
 /**
  * Dispatcher — execute a SQL query against the correct database type.
+ * Read-only enforcement and LIMIT safety are applied within each connector.
  */
 export async function executequery(type: string, config: ConnectionConfig, query: string): Promise<QueryResult> {
 	switch (type) {

--- a/packages/create-openzosma/README.md
+++ b/packages/create-openzosma/README.md
@@ -1,0 +1,72 @@
+# create-openzosma
+
+Interactive setup CLI for [OpenZosma](https://github.com/zosmaai/openzosma) -- the self-hosted AI agent platform.
+
+Go from zero to a running instance with a single command.
+
+## Quick start
+
+```bash
+# npm
+npx create-openzosma
+
+# pnpm
+pnpm create openzosma
+```
+
+The CLI walks you through the entire setup interactively -- no flags to memorize, no YAML to edit by hand.
+
+## What it does
+
+The setup pipeline runs 12 steps:
+
+| Step | What happens |
+|------|-------------|
+| **Prerequisites** | Checks for Node.js 22+, pnpm, Docker, Docker Compose, Git. Warns if OpenShell CLI is missing. |
+| **Project** | Clones the repo (or detects you're already inside one). |
+| **LLM provider** | Pick your provider and enter an API key. |
+| **Local model** | Optional. Configure a local/self-hosted model endpoint (Ollama, vLLM, etc.). |
+| **Database** | PostgreSQL connection details (defaults to `localhost:5432/openzosma`). |
+| **Sandbox** | Choose local mode or orchestrator mode with container isolation. |
+| **Auth** | Auto-generates `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY`. Optionally configure Google/GitHub OAuth. |
+| **.env** | Writes `.env.local` with all collected values. |
+| **Docker** | Starts PostgreSQL and Valkey via `docker compose up -d`. |
+| **Install** | Runs `pnpm install`. |
+| **Migrations** | Runs database schema and auth migrations. |
+| **Build** | Builds all packages with Turborepo. |
+
+At the end, it offers to start the gateway (port 4000) and dashboard (port 3000) for you.
+
+## Supported providers
+
+| Provider | Default model |
+|----------|--------------|
+| Anthropic | Claude Sonnet 4 |
+| OpenAI | GPT-4o |
+| Google | Gemini 2.5 Flash |
+| Groq | Llama 3.3 70B |
+| xAI | Grok 3 |
+| Mistral | Mistral Large |
+| Local model | Any OpenAI-compatible endpoint |
+
+## Post-clone mode
+
+Contributors who already cloned the repo can run:
+
+```bash
+pnpm setup
+```
+
+This skips the clone step and configures the existing checkout. The CLI auto-detects whether it's inside an OpenZosma repo.
+
+## Requirements
+
+- **Node.js** >= 22
+- **pnpm** (latest)
+- **Docker** and **Docker Compose**
+- **Git**
+- **OpenShell CLI** (optional, needed for orchestrator sandbox mode)
+
+## License
+
+Apache-2.0

--- a/packages/grpc/scripts/generate.ts
+++ b/packages/grpc/scripts/generate.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process"
+import { execFileSync } from "node:child_process"
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -22,7 +22,7 @@ for (const proto of protoFiles) {
 	const protoPath = join(protoDir, proto)
 	log.info(`Generating TypeScript from ${proto}...`)
 
-	execSync(`npx protoc --ts_out ${outDir} --proto_path ${protoDir} ${protoPath}`, { stdio: "inherit" })
+	execFileSync("npx", ["protoc", "--ts_out", outDir, "--proto_path", protoDir, protoPath], { stdio: "inherit" })
 }
 
 // Post-process: add .js extensions to relative imports for Node16 moduleResolution


### PR DESCRIPTION
## Summary

- Fix all 9 CodeQL security vulnerabilities flagged in the repository.
- Update the main README to lead with `create-openzosma` CLI as the primary setup path, with manual steps as an alternative.
- Add a `README.md` to the `create-openzosma` npm package.

### Security fixes (9/9 CodeQL issues resolved)

| # | Severity | File | Issue | Fix |
|---|----------|------|-------|-----|
| 1 | Medium | `.github/workflows/ci.yml` | Missing `permissions` block | Added `permissions: contents: read` |
| 2 | Medium | `packages/grpc/scripts/generate.ts` | Shell injection via `execSync` with template literal | Switched to `execFileSync` with array arguments |
| 3-4 | High | `apps/web/src/lib/db-connectors.ts` | SQL injection in `querypostgresql` / `querymysql` | Added read-only transaction enforcement (`BEGIN TRANSACTION READ ONLY` / `SET SESSION TRANSACTION READ ONLY`), application-level keyword blocklist, LIMIT safety cap, and CodeQL suppression comments on intentionally user-provided query lines |
| 5-9 | Medium | `apps/web/.../use-chat-stream.ts` | Prototype pollution via `toolcalls[toolCallId]` where `toolCallId` comes from parsed WebSocket JSON | Replaced `Record<string, StreamToolCall>` with `Map<string, StreamToolCall>` |

Also cleaned up duplicate `isreadonly` / `ensafelimit` / `BLOCKED_KEYWORDS` in `[integrationid]/query/route.ts` -- now centralized in `db-connectors.ts`.

### README updates

- **Main `README.md`**: Quick Start now leads with `pnpm create openzosma` / `npx create-openzosma` as the primary setup path. Manual steps moved under a "Manual Setup" sub-heading. Removed orphaned "Full Setup" heading and relocated the gateway env-file note.
- **`packages/create-openzosma/README.md`**: Added package README for the npm listing -- covers quick start, all 12 pipeline steps, supported providers, post-clone mode, and requirements.

### Changed files

| File | Change |
|------|--------|
| `README.md` | Quick Start restructured with CLI-first flow |
| `packages/create-openzosma/README.md` | New -- npm package README |
| `.github/workflows/ci.yml` | Added `permissions: contents: read` |
| `packages/grpc/scripts/generate.ts` | `execSync` to `execFileSync` with array args |
| `apps/web/src/lib/db-connectors.ts` | Read-only transaction enforcement in query functions |
| `apps/web/src/app/api/integrations/[integrationid]/query/route.ts` | Removed duplicate read-only logic (now in db-connectors) |
| `apps/web/src/components/organisms/chat-view/hooks/use-chat-stream.ts` | `Record` to `Map` for tool calls |

### Verification

- 17/17 build tasks pass
- 27/27 type-check tasks pass
- 384 files linted with zero issues (Biome)
