### PR TITLE
fix(pi-harness): remove private field to enable npm publish

### DIFF
--- a/packages/pi-harness/package.json
+++ b/packages/pi-harness/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@openzosma/pi-harness",
 	"version": "0.1.0",
-	"private": true,
 	"type": "module",
 	"description": "The top-level harness for the Pi ecosystem. Run pi-coding-agent and other Pi packages headlessly as a background HTTP/SSE server. Built with gratitude for Mario Zechner's pi-mono.",
 	"main": "dist/index.js",


### PR DESCRIPTION
Removes the `"private": true` flag from `packages/pi-harness/package.json` so the package can be published to npm. The release workflow was failing with `EPRIVATE` because this field blocked publication.